### PR TITLE
Update compiler/dcu module of wuzhen node.

### DIFF
--- a/abacus-dcu.md
+++ b/abacus-dcu.md
@@ -73,7 +73,7 @@ module purge
 
 ```bash
 1) compiler/devtoolset/7.3.1
-2) compiler/dtk/21.10          
+2) compiler/dtk/23.04          
 3) compiler/cmake/3.23.1
 4) mpi/hpcx/gcc-7.3.1
 ```


### PR DESCRIPTION
个人测试compiler/dcu/23.04的init部分比compiler/dcu/21.10更快，并且稳定性好，是否考虑更新DCU文档中的module要求？